### PR TITLE
Bugfix: Encode colon for cache file

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -970,6 +970,7 @@ class WP_Object_Cache {
 			'\'' => rawurlencode( '\'' ),
 			'<' => rawurlencode( '<' ),
 			'>' => rawurlencode( '>' ),
+			':' => rawurlencode( ':' ),
 		);
 
 		$key = str_replace( array_keys( $protected_chars ), $protected_chars, $key );


### PR DESCRIPTION
Colon in cache file cause error on Windows